### PR TITLE
refactor: createQueryKeys interface

### DIFF
--- a/src/app/query-options/chat.ts
+++ b/src/app/query-options/chat.ts
@@ -7,7 +7,7 @@ import { queryOptions } from '@tanstack/react-query';
 export const ChatQueryKey = createQueryKeys('chat', [
   'verifyToken',
   'createFriend',
-] as const);
+]);
 
 export const ChatQueryOptions = {
   verifyToken: <TTokenType extends TOKEN_TYPE>({

--- a/src/app/query-options/utils.ts
+++ b/src/app/query-options/utils.ts
@@ -4,7 +4,7 @@ import { API_ROUTES } from '@/routes/api';
 import { createQueryKeys } from '@/utils/createQueryKeys';
 import { queryOptions } from '@tanstack/react-query';
 
-export const UtilsQueryKey = createQueryKeys('utils', ['shortUrl'] as const);
+export const UtilsQueryKey = createQueryKeys('utils', ['shortUrl']);
 
 export const UtilsQueryOptions = {
   shortUrl: (url: string) =>

--- a/src/utils/createQueryKeys.ts
+++ b/src/utils/createQueryKeys.ts
@@ -1,6 +1,6 @@
 export const createQueryKeys = <TName extends string, TKeys extends string[]>(
   name: TName,
-  keys: TKeys,
+  keys: [...TKeys],
 ) => {
   const result = {} as Record<TKeys[number], `${TName}.${TKeys[number]}`>;
 


### PR DESCRIPTION
사용처에서 `as const`를 매번 작성하지않아도 됩니다.
